### PR TITLE
feat(analytics): add PostHog tracing headers for backend correlation

### DIFF
--- a/packages/analytics/instrumentation-client.ts
+++ b/packages/analytics/instrumentation-client.ts
@@ -2,8 +2,10 @@ import posthog from "posthog-js";
 import { keys } from "./keys";
 
 export const initializeAnalytics = () => {
+  const appUrl = new URL(keys().NEXT_PUBLIC_APP_URL);
   posthog.init(keys().NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: keys().NEXT_PUBLIC_POSTHOG_HOST,
     defaults: "2025-05-24",
+    __add_tracing_headers: [appUrl.hostname],
   });
 };

--- a/packages/analytics/keys.ts
+++ b/packages/analytics/keys.ts
@@ -7,10 +7,12 @@ export const keys = () =>
       NEXT_PUBLIC_POSTHOG_KEY: z.string().startsWith("phc_"),
       NEXT_PUBLIC_POSTHOG_HOST: z.string().url(),
       NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().startsWith("G-").optional(),
+      NEXT_PUBLIC_APP_URL: z.string().url(),
     },
     runtimeEnv: {
       NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
       NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
+      NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     },
   });


### PR DESCRIPTION
## Description

- Configure __add_tracing_headers with app hostname from NEXT_PUBLIC_APP_URL
- Add NEXT_PUBLIC_APP_URL to analytics keys schema for type safety
- Extract hostname from app URL for consistent cross-environment configuration
- Enables request tracing between PostHog frontend events and backend logs