### PR TITLE
feat: improve validation and add client creation to event sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,4 @@ packages/database/generated
 .contentlayer
 .content-collections
 .source
+.docs

--- a/apps/app/app/(authenticated)/estimates/components/create-client-dialog.tsx
+++ b/apps/app/app/(authenticated)/estimates/components/create-client-dialog.tsx
@@ -27,11 +27,14 @@ import { createClient } from "../../clients/actions";
 
 const clientFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
-  email: z.string().optional(),
-  phone: z
-    .string()
-    .regex(/^[0-9+]*$/, "Phone must contain only numbers and + sign")
-    .optional(),
+  email: z.union([
+    z.string().email("Invalid email address"),
+    z.literal("")
+  ]).optional(),
+  phone: z.union([
+    z.string().regex(/^(\+[0-9]+|[0-9]+)$/, "Phone must be either numbers only or start with + followed by numbers"),
+    z.literal("")
+  ]).optional(),
   company: z.string().optional(),
 });
 

--- a/apps/app/app/(authenticated)/estimates/components/create-lead-dialog.tsx
+++ b/apps/app/app/(authenticated)/estimates/components/create-lead-dialog.tsx
@@ -35,10 +35,10 @@ import { createLead } from "../../leads/actions";
 const leadFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   email: z.string().email().optional(),
-  phone: z
-    .string()
-    .regex(/^[0-9+]*$/, "Phone must contain only numbers and + sign")
-    .optional(),
+  phone: z.union([
+    z.string().regex(/^(\+[0-9]+|[0-9]+)$/, "Phone must be either numbers only or start with + followed by numbers"),
+    z.literal("")
+  ]).optional(),
   company: z.string().optional(),
   status: z.enum([
     "NEW",

--- a/apps/app/app/(authenticated)/events/components/event-sheet.tsx
+++ b/apps/app/app/(authenticated)/events/components/event-sheet.tsx
@@ -18,6 +18,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@repo/design-system/components/ui/command";
 import {
   Select,
@@ -26,7 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@repo/design-system/components/ui/select";
-import { CalendarIcon, Check, ChevronsUpDown, Pencil, ArrowRight } from "lucide-react";
+import { CalendarIcon, Check, ChevronsUpDown, Pencil, ArrowRight, Plus } from "lucide-react";
 import { createEvent, updateEvent, getEstimatesForLeadOrClient } from "../actions";
 import { getClients } from "../../clients/actions";
 import { getLeads } from "../../leads/actions";
@@ -35,6 +36,7 @@ import { useTransition, useEffect, useState } from "react";
 import { cn } from "@repo/design-system/lib/utils";
 import { format } from "date-fns";
 import { useRouter } from "next/navigation";
+import { CreateClientDialog } from "../../estimates/components/create-client-dialog";
 
 interface EventSheetProps {
   open: boolean;
@@ -71,6 +73,7 @@ export function EventSheet({ open, onOpenChange, event, mode: initialMode, onSuc
   
   const [leadClientOpen, setLeadClientOpen] = useState(false);
   const [estimateOpen, setEstimateOpen] = useState(false);
+  const [createClientDialogOpen, setCreateClientDialogOpen] = useState(false);
 
   const isViewing = mode === "view";
   const isEditing = mode === "edit";
@@ -294,6 +297,17 @@ export function EventSheet({ open, onOpenChange, event, mode: initialMode, onSuc
 
   const selectedEstimate = estimates.find(e => e.id === estimateId);
 
+  const handleClientCreated = (clientId: string, clientName: string) => {
+    // Add to local state
+    setClients(prev => [...prev, { id: clientId, name: clientName, email: null }]);
+
+    // Auto-select the new client
+    setLeadOrClientId(clientId);
+    setLeadOrClientType("client");
+
+    // Toast already shown by dialog
+  };
+
   return (
     <>
       <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -348,8 +362,40 @@ export function EventSheet({ open, onOpenChange, event, mode: initialMode, onSuc
                   <PopoverContent className="w-full p-0" align="start">
                     <Command>
                       <CommandInput placeholder="Search leads and clients..." />
-                      <CommandList>
-                        <CommandEmpty>No lead or client found.</CommandEmpty>
+                      <CommandList className="max-h-[300px] overflow-y-auto">
+                        <CommandEmpty>
+                          <div className="py-6 text-center">
+                            <p className="mb-4 text-sm text-muted-foreground">No client found.</p>
+                            <div className="px-4">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="w-full"
+                                onClick={() => {
+                                  setLeadClientOpen(false);
+                                  setCreateClientDialogOpen(true);
+                                }}
+                              >
+                                <Plus className="mr-2 h-4 w-4" />
+                                Create New Client
+                              </Button>
+                            </div>
+                          </div>
+                        </CommandEmpty>
+                        <CommandGroup>
+                          <CommandItem
+                            onSelect={() => {
+                              setLeadClientOpen(false);
+                              setCreateClientDialogOpen(true);
+                            }}
+                            className="text-primary"
+                          >
+                            <Plus className="mr-2 h-4 w-4" />
+                            Create New Client
+                          </CommandItem>
+                        </CommandGroup>
+                        <CommandSeparator />
                         {leads.length > 0 && (
                           <CommandGroup heading="Leads">
                             {leads.map((lead) => (
@@ -698,6 +744,13 @@ export function EventSheet({ open, onOpenChange, event, mode: initialMode, onSuc
           </form>
         </SheetContent>
       </Sheet>
+
+      {/* Client Creation Dialog */}
+      <CreateClientDialog
+        open={createClientDialogOpen}
+        onOpenChange={setCreateClientDialogOpen}
+        onSuccess={handleClientCreated}
+      />
     </>
   );
 }


### PR DESCRIPTION
Enhance lead/client creation dialogs with stricter validation and extend inline creation capability to event workflow.

Validation Improvements:
- Update email validation in create-client-dialog to use z.union pattern with email validator and empty literal
- Fix phone regex from /^[0-9+]*$/ to /^(\+[0-9]+|[0-9]+)$/ in both dialogs
- Wrap phone validation in z.union with empty literal for better optional field handling
- Prevent invalid formats like "123123+" from passing validation
- Ensure validation errors display inline via FormMessage instead of toasts

Event Sheet Integration:
- Add CreateClientDialog component to event-sheet for inline client creation
- Position "Create New Client" button at top of lead/client selector list
- Add scrollable list with max-h-[300px] overflow-y-auto for better UX with long lists
- Auto-select newly created client with handleClientCreated callback
- Update CommandEmpty state to show creation option when no results found
- Import CommandSeparator and Plus icon for consistent UI patterns

Other Changes:
- Add .docs to .gitignore for documentation build artifacts

Benefits:
- Users can create clients without leaving event creation workflow
- Validation provides clearer feedback with inline errors
- Phone numbers now follow strict international (+prefix) or domestic (numbers only) format
- Improved UX with scrollable lists and prominent creation button placement
- Consistent experience across estimate and event workflows

Files modified:
- apps/app/app/(authenticated)/estimates/components/create-lead-dialog.tsx
- apps/app/app/(authenticated)/estimates/components/create-client-dialog.tsx
- apps/app/app/(authenticated)/events/components/event-sheet.tsx
- .gitignore

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
