### PR TITLE
fix: resolve CORS issue blocking Cal.com embed on mobile

### DIFF
--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -78,7 +78,8 @@ export default authMiddleware(async (auth, request) => {
     }
   }
 
-  return securityHeaders();
+  // Use relaxed security headers for authenticated routes to allow Cal.com embeds
+  return relaxedSecurityHeaders();
 }) as unknown as NextMiddleware;
 
 export const config = {


### PR DESCRIPTION
- Relax Cross-Origin-Embedder-Policy for authenticated routes to allow Cal.com iframes
- Apply same security pattern used for Stripe embeds